### PR TITLE
Fjern link til swagger

### DIFF
--- a/code_and_tutorials/getting started - fritekstsok/README.md
+++ b/code_and_tutorials/getting started - fritekstsok/README.md
@@ -2,7 +2,6 @@
 
 ## Relevant Documentation and Links
 - [Fritekstsøk Documentation](./../../API-fritekstsok)
-- [Fritekstsøk Swagger](https://fritekstsok.api.norkart.no/swagger-ui/)
 
 ## HowTo
 - [HowTo: Refine search for municipalities](./HowTo/KOMMUNECUSTOM.md)


### PR DESCRIPTION
Vi har ikke lenger swagger for fritekstsøk tilgjenglig pga sikkerhet. Nå leder denne linken bare til en tom side